### PR TITLE
docs(MOSSMVP135): README.md rewrite. Changes to documentation website structure (header, footer navigation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ sudo apt install libsoup-3.0-dev
 - Before running any applications, ensure that SurrealDB is started:
 
 ```sh
-cd ./view/desktop/
-surreal start file:rocksdb
+cd ./view/desktop/ && surreal start file:rocksdb
 ```
 
 - Run all apps:
@@ -80,51 +79,6 @@ pnpm doc
 
 ```sh
 pnpm turbo run build --graph
-```
-
-## What's inside?
-
-### Project Folder Structure
-
-The Moss project is organized into several key directories, each serving a distinct purpose in the development process. Below is a detailed description of the folder structure:
-
-```
-platform
-│
-├── view
-│   ├── docs
-│   │   └── Documentation website built with [Docusaurus](https://docusaurus.io/). This site hosts the project documentation.
-│   │
-│   ├── storybook
-│   │   └── [Storybook](https://storybook.js.org/) setup for developing and showcasing UI components in isolation.
-│   │
-│   ├── shared
-│       ├── ui
-│       │   └── Shared UI components such as buttons, texts, and other reusable elements.
-│       │
-│       ├── web
-│       │   └── Web application code.
-│       │
-│       └── desktop
-│           └── Desktop application code. The desktop app is built with TypeScript and [Tauri](https://tauri.app/).
-│
-├── platform
-│   └── Backend code for the Moss platform.
-│
-├── kernel
-│   └── Rust abstractions over OS kernel functions, such as filesystem (fs) and bus operations. (CONFIRMED)
-│
-├── lib
-│   └── **(Pending Confirmation)**: The exact purpose of this directory is unclear and requires further clarification.
-│
-├── mossctl
-│   └── **(Pending Confirmation)**: The exact role of this directory is unclear and needs further clarification.
-│
-├── net
-│   └── This directory contains Rust networking functions (CONFIRM!!)
-│
-└── src
-    └── Rust entry point for the application.
 ```
 
 ### Key Notes:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,35 @@
 
 We would for you to get involved with Moss development! If you wish to help, you can learn more about how you can contribute to this project in the [contribution guide](CONTRIBUTING.md).
 
+# Requirements
+
+Before starting the project, ensure you have the following installed:
+
+- [SurrealDB](https://surrealdb.com/)
+- [Tauri](https://tauri.app/)
+- [pnpm](https://pnpm.io/)
+- [Rust](https://www.rust-lang.org/)
+
+On the first app start, Tauri may prompt you to install additional dependencies. These dependencies are described in the [Tauri Getting Started Guide](https://tauri.app/v1/guides/getting-started/prerequisites).
+
+**Note for Ubuntu Linux users:**
+
+Based on personal experience, some additional libraries may be required:
+
+```sh
+sudo apt install libwebkit2gtk-4.1-dev
+sudo apt install libjavascriptcoregtk-4.1-dev
+sudo apt install libsoup-3.0-dev
+```
+
 # Usage
+
+- Before running any applications, ensure that SurrealDB is started:
+
+```sh
+cd ./view/desktop/
+surreal start file:rocksdb
+```
 
 - Run all apps:
 
@@ -41,7 +69,7 @@ pnpm web
 - Run docs app:
 
 ```sh
-pnpm doki
+pnpm doc
 ```
 
 - Generate monorepo project dependency graph:
@@ -50,61 +78,51 @@ pnpm doki
 pnpm turbo run build --graph
 ```
 
-## Turborepo Tailwind CSS starter
-
-This is an official starter Turborepo.
-
-## Using this example
-
-Run the following command:
-
-```sh
-npx create-turbo@latest -e with-tailwind
-```
-
 ## What's inside?
 
-This Turborepo includes the following packages/apps:
+### Project Folder Structure
 
-### Apps and Packages
+The Moss project is organized into several key directories, each serving a distinct purpose in the development process. Below is a detailed description of the folder structure:
 
-- `docs`: a [Next.js](https://nextjs.org/) app with [Tailwind CSS](https://tailwindcss.com/)
-- `web`: another [Next.js](https://nextjs.org/) app with [Tailwind CSS](https://tailwindcss.com/)
-- `ui`: a stub React component library with [Tailwind CSS](https://tailwindcss.com/) shared by both `web` and `docs` applications
-- `@repo/eslint-config`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
-- `@repo/typescript-config`: `tsconfig.json`s used throughout the monorepo
-
-Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).
-
-### Building packages/ui
-
-This example is set up to produce compiled styles for `ui` components into the `dist` directory. The component `.tsx` files are consumed by the Next.js apps directly using `transpilePackages` in `next.config.js`. This was chosen for several reasons:
-
-- Make sharing one `tailwind.config.js` to apps and packages as easy as possible.
-- Make package compilation simple by only depending on the Next.js Compiler and `tailwindcss`.
-- Ensure Tailwind classes do not overwrite each other. The `ui` package uses a `ui-` prefix for it's classes.
-- Maintain clear package export boundaries.
-
-Another option is to consume `packages/ui` directly from source without building. If using this option, you will need to update the `tailwind.config.js` in your apps to be aware of your package locations, so it can find all usages of the `tailwindcss` class names for CSS compilation.
-
-For example, in [tailwind.config.js](packages/tailwind-config/tailwind.config.js):
-
-```js
-  content: [
-    // app content
-    `src/**/*.{js,ts,jsx,tsx}`,
-    // include packages if not transpiling
-    "../../packages/ui/*.{js,ts,jsx,tsx}",
-  ],
+```
+platform
+│
+├── view
+│   ├── docs
+│   │   └── Documentation website built with [Docusaurus](https://docusaurus.io/). This site hosts the project documentation.
+│   │
+│   ├── storybook
+│   │   └── [Storybook](https://storybook.js.org/) setup for developing and showcasing UI components in isolation.
+│   │
+│   ├── shared
+│       ├── ui
+│       │   └── Shared UI components such as buttons, texts, and other reusable elements.
+│       │
+│       ├── web
+│       │   └── Web application code.
+│       │
+│       └── desktop
+│           └── Desktop application code. The desktop app is built with TypeScript and [Tauri](https://tauri.app/).
+│
+├── platform
+│   └── Backend code for the Moss platform.
+│
+├── kernel
+│   └── Rust abstractions over OS kernel functions, such as filesystem (fs) and bus operations. (CONFIRMED)
+│
+├── lib
+│   └── **(Pending Confirmation)**: The exact purpose of this directory is unclear and requires further clarification.
+│
+├── mossctl
+│   └── **(Pending Confirmation)**: The exact role of this directory is unclear and needs further clarification.
+│
+├── net
+│   └── This directory contains Rust networking functions (CONFIRM!!)
+│
+└── src
+    └── Rust entry point for the application.
 ```
 
-If you choose this strategy, you can remove the `tailwindcss` and `autoprefixer` dependencies from the `ui` package.
+### Key Notes:
 
-### Utilities
-
-This Turborepo has some additional tools already setup for you:
-
-- [Tailwind CSS](https://tailwindcss.com/) for styles
-- [TypeScript](https://www.typescriptlang.org/) for static type checking
-- [ESLint](https://eslint.org/) for code linting
-- [Prettier](https://prettier.io) for code formatting
+- **Desktop App**: The desktop application is developed using [TypeScript](https://www.typescriptlang.org/) and [Tauri](https://tauri.app/), which allows for building cross-platform applications with [Rust](https://www.rust-lang.org/) and Web technologies.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Moss
 
 - [Contributing](#contributing)
+- [Requirements](#requirements)
+- [Usage](#usage)
+- [Project Folder Structure](#project-folder-structure)
+- [Key Notes](#key-notes)
 
 ## Contributing
 

--- a/view/docs/community/index.md
+++ b/view/docs/community/index.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 1
+---
+
+# Community
+
+Community docs are located in `view/docs/community`
+
+without index.md docusaurus won't see any docs

--- a/view/docs/community/index.md
+++ b/view/docs/community/index.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Overwiew
+# Overview
 
 Community docs are located in `view/docs/community`
 

--- a/view/docs/community/index.md
+++ b/view/docs/community/index.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Community
+# Overwiew
 
 Community docs are located in `view/docs/community`
 

--- a/view/docs/community/overview/_category_.json
+++ b/view/docs/community/overview/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Overview",
+  "position": 1,
+  "link": {
+    "type": "generated-index",
+    "description": "High-level platform overview"
+  }
+}

--- a/view/docs/community/overview/_category_.json
+++ b/view/docs/community/overview/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Overview",
+  "label": "Desktop (example)",
   "position": 1,
   "link": {
     "type": "generated-index",

--- a/view/docs/community/overview/first_page.md
+++ b/view/docs/community/overview/first_page.md
@@ -1,0 +1,5 @@
+---
+sidebar_position: 1
+---
+
+# First page

--- a/view/docs/docusaurus.config.ts
+++ b/view/docs/docusaurus.config.ts
@@ -58,6 +58,7 @@ const config: Config = {
         sidebarPath: "./sidebars.ts",
       },
     ],
+    // NOTE: commented-out code left as an example
     // [
     //   "@docusaurus/plugin-content-docs",
     //   {
@@ -76,6 +77,7 @@ const config: Config = {
         src: "img/logo.svg",
       },
       items: [
+        // NOTE: commented-out code left as an example
         // {
         //   type: "docSidebar",
         //   sidebarId: "tutorialSidebar",
@@ -102,6 +104,7 @@ const config: Config = {
             },
           ],
         },
+        // NOTE: commented-out code left as an example
         // {
         //   title: "Community",
         //   items: [

--- a/view/docs/docusaurus.config.ts
+++ b/view/docs/docusaurus.config.ts
@@ -43,9 +43,9 @@ const config: Config = {
     [
       "@docusaurus/plugin-content-docs",
       {
-        id: "desktop",
-        path: "../desktop/docs",
-        routeBasePath: "desktop",
+        id: "community",
+        path: "./community",
+        routeBasePath: "community",
         sidebarPath: "./sidebars.ts",
       },
     ],
@@ -58,15 +58,15 @@ const config: Config = {
         sidebarPath: "./sidebars.ts",
       },
     ],
-    [
-      "@docusaurus/plugin-content-docs",
-      {
-        id: "shared",
-        path: "../shared/docs",
-        routeBasePath: "shared",
-        sidebarPath: "./sidebars.ts",
-      },
-    ],
+    // [
+    //   "@docusaurus/plugin-content-docs",
+    //   {
+    //     id: "shared",
+    //     path: "../shared/docs",
+    //     routeBasePath: "shared",
+    //     sidebarPath: "./sidebars.ts",
+    //   },
+    // ],
   ],
   themeConfig: {
     navbar: {
@@ -76,16 +76,13 @@ const config: Config = {
         src: "img/logo.svg",
       },
       items: [
-        {
-          type: "docSidebar",
-          sidebarId: "tutorialSidebar",
-          position: "left",
-          label: "Tutorial",
-        },
-        { to: "/desktop", label: "desktop", position: "left" },
-        { to: "/web", label: "web", position: "left" },
-        { to: "/shared", label: "shared", position: "left" },
-        { to: "/blog", label: "blog", position: "left" },
+        // {
+        //   type: "docSidebar",
+        //   sidebarId: "tutorialSidebar",
+        //   position: "left",
+        //   label: "Tutorial",
+        // },
+        { to: "/community", label: "Community", position: "left" },
         {
           href: "https://github.com/4rchr4y/moss",
           label: "Moss",
@@ -100,41 +97,41 @@ const config: Config = {
           title: "Docs",
           items: [
             {
-              label: "Tutorial",
-              to: "/docs/intro",
+              label: "Community",
+              to: "/community",
             },
           ],
         },
-        {
-          title: "Community",
-          items: [
-            {
-              label: "Stack Overflow",
-              href: "https://stackoverflow.com/questions/tagged/docusaurus",
-            },
-            {
-              label: "Discord",
-              href: "https://discordapp.com/invite/docusaurus",
-            },
-            {
-              label: "Twitter",
-              href: "https://twitter.com/docusaurus",
-            },
-          ],
-        },
-        {
-          title: "More",
-          items: [
-            {
-              label: "Blog",
-              to: "/blog",
-            },
-            {
-              label: "GitHub",
-              href: "https://github.com/facebook/docusaurus",
-            },
-          ],
-        },
+        // {
+        //   title: "Community",
+        //   items: [
+        //     {
+        //       label: "Stack Overflow",
+        //       href: "https://stackoverflow.com/questions/tagged/docusaurus",
+        //     },
+        //     {
+        //       label: "Discord",
+        //       href: "https://discordapp.com/invite/docusaurus",
+        //     },
+        //     {
+        //       label: "Twitter",
+        //       href: "https://twitter.com/docusaurus",
+        //     },
+        //   ],
+        // },
+        // {
+        //   title: "More",
+        //   items: [
+        //     {
+        //       label: "Blog",
+        //       to: "/blog",
+        //     },
+        //     {
+        //       label: "GitHub",
+        //       href: "https://github.com/facebook/docusaurus",
+        //     },
+        //   ],
+        // },
       ],
       copyright: `Copyright © ${new Date().getFullYear()} My Project, Inc. Built with Docusaurus.`,
     },


### PR DESCRIPTION
Now docs look like this:
![Screenshot](https://github.com/user-attachments/assets/d66ac07b-9c8c-4487-9792-22a6382aac04)
